### PR TITLE
Serve frontend build through express

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,13 @@ npm run install-project
 npm run dev
 ```
 
+### Production
+
+För att köra production lokalt (med inloggning) så borde du först köra `npm run build-client` för att uppdatera `client/build`.
+Kör sedan följande kommando för att hosta servern med react-frontend på `http://localhost:8080`:
+
+`npm run staging`
+
 ### Tester
 
 Kör testerna med `npm test`. Beroende på vilken mapp du befinner dig i så körs olika tester (närmaste `package.json` bestämmer). Alla tester körs om du är i rot-mappen, annars körs antingen alla `client/` tester eller alla `server/` tester.

--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ Kör sedan följande kommando för att hosta servern med react-frontend på `htt
 
 `npm run staging`
 
+För den faktiska production-miljön med inloggning mot login.kth.se så körs
+
+`npm run pro`
+
 ### Tester
 
 Kör testerna med `npm test`. Beroende på vilken mapp du befinner dig i så körs olika tester (närmaste `package.json` bestämmer). Alla tester körs om du är i rot-mappen, annars körs antingen alla `client/` tester eller alla `server/` tester.

--- a/package.json
+++ b/package.json
@@ -7,9 +7,10 @@
     "server": "npm start --prefix server",
     "client": "npm start --prefix client",
     "dev": "concurrently \"npm run server\" \"npm run client\" --names \"server,client\"",
-    "build-server": "npm run build-ts --prefix server",
+    "pro": "NODE_ENV=production npm run server",
+    "compile-server": "npm run compile-ts --prefix server",
     "build-client": "npm run build --prefix client",
-    "build": "npm run build-client && npm run build-server",
+    "build": "npm run build-client && npm run compile-server",
     "test-client": "CI=True npm test --prefix client",
     "test-server": "npm test --prefix server",
     "test": "npm run test-server && npm run test-client"

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "client": "npm start --prefix client",
     "dev": "concurrently \"npm run server\" \"npm run client\" --names \"server,client\"",
     "pro": "NODE_ENV=production npm run server",
+    "staging": "NODE_ENV=staging npm run server",
     "compile-server": "npm run compile-ts --prefix server",
     "build-client": "npm run build --prefix client",
     "build": "npm run build-client && npm run compile-server",

--- a/server/package.json
+++ b/server/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "main": "dist/server/src/server.js",
   "scripts": {
-    "build-ts": "tsc",
+    "compile-ts": "tsc",
     "watch-ts": "tsc -w",
     "start": "concurrently \"npm run watch-ts\" \"npm run serve\" --names \"compilation,server\"",
     "serve": "nodemon dist/server/src/server.js",

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -1,5 +1,6 @@
 import express from "express"
 import session, { MemoryStore } from "express-session"
+import path from "path"
 
 const mongoose = require("mongoose")
 const MongoStore = require('connect-mongo')(session)
@@ -56,6 +57,11 @@ let casAuth; // initialise depending on environment below
 switch (app.get("env")){
     case "production":
         casAuth = CAS(CASOptionsPro) // production settings
+        // In production it is run in /server/dist/server/src/server.js, so go back 4 dirs.
+        // for consistency the FAS_ROOT_DIR env var should be set to the absolute path of client/build.
+        const FAS_ROOT_DIR = process.env.FAS_ROOT_DIR || path.join(__dirname, '../../../../')
+        app.set('static_folder', path.join(FAS_ROOT_DIR, 'client/build'))
+        app.use('/', express.static(app.get('static_folder')))
         break
     case "testing":
         casAuth = CAS(CASOptionsDev) // development settings

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -52,23 +52,23 @@ app.use( session({
 // exposes json request attributes on req.body
 app.use(bodyParser.json())
 
-let casAuth; // initialise depending on environment below
+
+// initialise CAS depending on environment below
+let casAuth; 
 
 switch (app.get("env")){
     case "production":
         casAuth = CAS(CASOptionsPro) // production settings
-        // In production it is run in /server/dist/server/src/server.js, so go back 4 dirs.
-        // for consistency the FAS_ROOT_DIR env var should be set to the absolute path of client/build.
-        const FAS_ROOT_DIR = process.env.FAS_ROOT_DIR || path.join(__dirname, '../../../../')
-        app.set('static_folder', path.join(FAS_ROOT_DIR, 'client/build'))
-        app.use('/', express.static(app.get('static_folder')))
+        break
+    case "staging":
+        casAuth = CAS(CASOptionsDev) // development settings
         break
     case "testing":
         casAuth = CAS(CASOptionsDev) // development settings
         // this route is for testing
         app.get("/block_unauthorized", casAuth.block, (req,res)=>res.send("Your request was not blocked"))
         break
-    default: // development
+    default: // env development
         const corsOptions = {
             origin: 'http://localhost:3000',  // react frontend during development
             optionsSuccessStatus: 200 // some legacy browsers (IE11, various SmartTVs) choke on 204
@@ -86,7 +86,22 @@ app.get("/api/me", (req,res) => res.json({name:req.session['cas_user']}))
 /* Other routes */
 app.get("/login", casAuth.bounce_redirect) // requires 
 app.get("/logout", casAuth.logout)
-app.get("/", casAuth.bounce, (req,res) => res.send("Temporary homepage"))
+// app.get("/", casAuth.bounce, (req,res) => res.send("Temporary homepage"))
+
+// In production it is run in /server/dist/server/src/server.js, so go back 4 dirs.
+// for consistency the FAS_ROOT_DIR env var should be set to the absolute path of the project.
+const FAS_ROOT_DIR = process.env.FAS_ROOT_DIR || path.join(__dirname, '../../../../')
+app.set('static_folder', path.join(FAS_ROOT_DIR, 'client/build'))
+// this clause needs to be at the end since we want the backend routes to run first.
+if (["production", "staging"].includes(app.get("env"))){
+    app.use('/', express.static(app.get('static_folder')))
+    // send index.html if the route is not found.
+    // this part is crucial in order to work with react router for
+    // views like /groups 
+    app.get('*', (req, res) => {
+        res.sendFile('index.html', {root: path.join(FAS_ROOT_DIR, 'client/build/')});
+    })
+}
 
 
 export default app

--- a/server/src/test/api.test.ts
+++ b/server/src/test/api.test.ts
@@ -26,7 +26,7 @@ function checkGroupResponse(groupNode:any){
 async function getAuthedSession() {
     const sess = session(app)
     // route "/" redirects users to login, in dev/test mode this is done automatically
-    await sess.get("/").expect(200)
+    await sess.get("/login").expect(302)
     return sess
 }
 


### PR DESCRIPTION
Serve react build through express. This allows one to login and access the restricted pages.

See the changes to the README. To login go to http://localhost:8080/login after running `npm run staging`. A button for the login is needed.

Currently the frontend /listview doesn't work if not logged in because the client doesn't handle the 401  response from backend. Should this view be public? Currently the backend blocks unautheticated requests to /api/groups.